### PR TITLE
add order select

### DIFF
--- a/prefetch/PrefetchHydrator.ts
+++ b/prefetch/PrefetchHydrator.ts
@@ -1,4 +1,4 @@
-import { Hook, HookPrefetch } from '../resources/HookTypes';
+import { Hook, HookPrefetch, TypedRequestBody } from '../resources/HookTypes';
 import { ServicePrefetch } from '../resources/CdsService';
 import { FhirResource } from 'fhir/r4';
 function jsonPath(json: any, path: string) {
@@ -47,11 +47,11 @@ function replaceTokens(str: string, json: Hook): string {
   // Return the modified string
   return str;
 }
-function resolveToken(token: string, callback: (token: string) => Promise<any>, hook: Hook) {
+function resolveToken(token: string, callback: (token: string, req: TypedRequestBody) => Promise<any>, hook: Hook) {
   const fulfilledToken = replaceTokens(token, hook);
-  return callback(fulfilledToken);
+  return callback(fulfilledToken, {body: hook});
 }
-function hydrate(callback: (token: string) => Promise<any>, template: ServicePrefetch, hook: Hook) {
+function hydrate(callback: (token: string, req: TypedRequestBody) => Promise<any>, template: ServicePrefetch, hook: Hook) {
   // Generally the EHR should define the prefetch requests it will/won't
   // fulfill, but in this case we can just attempt to fill everything
   // we can.

--- a/prefetch/PrefetchHydrator.ts
+++ b/prefetch/PrefetchHydrator.ts
@@ -47,11 +47,19 @@ function replaceTokens(str: string, json: Hook): string {
   // Return the modified string
   return str;
 }
-function resolveToken(token: string, callback: (token: string, req: TypedRequestBody) => Promise<any>, hook: Hook) {
+function resolveToken(
+  token: string,
+  callback: (token: string, req: TypedRequestBody) => Promise<any>,
+  hook: Hook
+) {
   const fulfilledToken = replaceTokens(token, hook);
-  return callback(fulfilledToken, {body: hook});
+  return callback(fulfilledToken, { body: hook });
 }
-function hydrate(callback: (token: string, req: TypedRequestBody) => Promise<any>, template: ServicePrefetch, hook: Hook) {
+function hydrate(
+  callback: (token: string, req: TypedRequestBody) => Promise<any>,
+  template: ServicePrefetch,
+  hook: Hook
+) {
   // Generally the EHR should define the prefetch requests it will/won't
   // fulfill, but in this case we can just attempt to fill everything
   // we can.

--- a/resources/HookTypes.ts
+++ b/resources/HookTypes.ts
@@ -1,7 +1,8 @@
 import { Bundle, FhirResource, Patient, Practitioner } from 'fhir/r4';
 
 export enum SupportedHooks {
-  ORDER_SIGN = 'order-sign'
+  ORDER_SIGN = 'order-sign',
+  ORDER_SELECT = 'order-select'
 }
 
 export interface FhirAuthorization {
@@ -13,7 +14,7 @@ export interface FhirAuthorization {
 }
 
 export interface HookContext {
-  [key: string]: string | Bundle | undefined;
+  [key: string]: string | string[] | Bundle | undefined;
 }
 
 export interface HookPrefetch {
@@ -21,6 +22,11 @@ export interface HookPrefetch {
 }
 
 export interface OrderSignPrefetch extends HookPrefetch {
+  practitioner?: Practitioner;
+  patient?: Patient;
+}
+
+export interface OrderSelectPrefetch extends HookPrefetch {
   practitioner?: Practitioner;
   patient?: Patient;
 }
@@ -40,11 +46,24 @@ export interface OrderSignContext extends HookContext {
   encounterId?: string;
   draftOrders: Bundle;
 }
+
+// https://cds-hooks.org/hooks/order-select/#context
+export interface OrderSelectContext extends HookContext {
+  userId: string;
+  patientId: string;
+  encounterId?: string;
+  selections: string[];
+  draftOrders: Bundle;
+}
 // https://cds-hooks.hl7.org/1.0/#calling-a-cds-service
 export interface OrderSignHook extends Hook {
-  hook: SupportedHooks.ORDER_SIGN;
   context: OrderSignContext;
   prefetch?: OrderSignPrefetch;
+}
+
+export interface OrderSelectHook extends Hook {
+  context: OrderSelectContext;
+  prefetch?: OrderSelectPrefetch;
 }
 
 export interface Coding {
@@ -263,3 +282,7 @@ export interface Card {
    */
   links?: Link[];
 }
+
+export interface TypedRequestBody extends Express.Request {
+  body: Hook;
+}  

--- a/resources/HookTypes.ts
+++ b/resources/HookTypes.ts
@@ -285,4 +285,4 @@ export interface Card {
 
 export interface TypedRequestBody extends Express.Request {
   body: Hook;
-}  
+}

--- a/resources/OrderSelect.ts
+++ b/resources/OrderSelect.ts
@@ -6,14 +6,14 @@ export default class OrderSelect extends CdsHook {
   patientId: string;
   userId: string;
   draftOrders: Bundle;
-  selections: string[]
+  selections: string[];
 
   constructor(patientId: string, userId: string, draftOrders: Bundle, selections: string[]) {
     super(SupportedHooks.ORDER_SIGN);
     this.patientId = patientId;
     this.userId = userId;
     this.draftOrders = draftOrders;
-    this.selections = selections
+    this.selections = selections;
   }
 
   generate(): OrderSelectHook {

--- a/resources/OrderSelect.ts
+++ b/resources/OrderSelect.ts
@@ -1,0 +1,35 @@
+import { Bundle } from 'fhir/r4';
+import CdsHook from './CdsHook';
+import { OrderSelectContext, OrderSelectHook, SupportedHooks } from './HookTypes';
+
+export default class OrderSelect extends CdsHook {
+  patientId: string;
+  userId: string;
+  draftOrders: Bundle;
+  selections: string[]
+
+  constructor(patientId: string, userId: string, draftOrders: Bundle, selections: string[]) {
+    super(SupportedHooks.ORDER_SIGN);
+    this.patientId = patientId;
+    this.userId = userId;
+    this.draftOrders = draftOrders;
+    this.selections = selections
+  }
+
+  generate(): OrderSelectHook {
+    return {
+      hook: this.hookType,
+      hookInstance: this.hookInstance,
+      context: this.generateContext(),
+      prefetch: {}
+    };
+  }
+  generateContext(): OrderSelectContext {
+    return {
+      userId: this.userId,
+      patientId: this.patientId,
+      draftOrders: this.draftOrders,
+      selections: this.selections
+    };
+  }
+}


### PR DESCRIPTION
adds order select types for usage by order select hook send/receive in REMS admin and REMS SMART app.