### PR TITLE
Add types for handleCard-titled functions so they don't use `any`

### DIFF
--- a/resources/HookTypes.ts
+++ b/resources/HookTypes.ts
@@ -1,3 +1,4 @@
+import express from 'express';
 import { Bundle, FhirResource, Patient, Practitioner } from 'fhir/r4';
 
 export enum SupportedHooks {
@@ -314,6 +315,6 @@ export interface Card {
   links?: Link[];
 }
 
-export interface TypedRequestBody {
-  body: Hook;
-}
+export type TypedRequestBody = Pick<express.Request, 'body'>;
+
+export type TypedResponseBody = express.Response;


### PR DESCRIPTION
Related to https://github.com/mcode/rems-admin/pull/148 / [REMS-693](https://jira.mitre.org/browse/REMS-693)

Used with https://github.com/mcode/rems-admin/pull/148